### PR TITLE
user画面に過去の番号を表示

### DIFF
--- a/front/src/components/BingoGrid.vue
+++ b/front/src/components/BingoGrid.vue
@@ -6,9 +6,9 @@
         {{ cellIndex === 2 && rowIndex === 2 ? 'Free' : cell }}
       </div>
     </div>
-    <div class="status">
-      {{ currentStatusString }}
-    </div>
+  </div>
+  <div class="status">
+    {{ currentStatusString }}
   </div>
 </template>
 
@@ -119,9 +119,10 @@ watch(markedCells, checkBingoAndReach, { deep: true });
 }
 
 .status {
-  margin-top: 20px;
+  margin-top: 12px;
   color: #fff;
   font-size: 20px;
+  text-align: center;
 }
 
 @media (max-width: 600px) {

--- a/front/src/gateway/index.ts
+++ b/front/src/gateway/index.ts
@@ -16,6 +16,6 @@ watch([name, currentStatus], ([newName, newStatus]) => {
     name: newName,
     status: newStatus,
     uuid: uuid.value,
-    allNumbers: allNumbers.value,
+    currentNumber: allNumbers.value[allNumbers.value.length - 1],
   });
 });

--- a/front/src/gateway/index.ts
+++ b/front/src/gateway/index.ts
@@ -1,14 +1,14 @@
 import { io } from "socket.io-client";
 import { watch } from "vue";
-import { currentNumber, name, currentStatus, uuid } from "@/states";
+import { allNumbers, name, currentStatus, uuid } from "@/states";
 import { isDev } from "@/utils/is_dev";
 
 const socket = io(isDev ? "http://localhost:8000" : "/", {
   path: isDev ? "/socket.io" : "/user-socket/socket.io",
 });
 
-socket.on("nextNumber", (number: number) => {
-  currentNumber.value = number;
+socket.on("allNumbers", (numbers: number[]) => {
+  allNumbers.value = numbers;
 });
 
 watch([name, currentStatus], ([newName, newStatus]) => {
@@ -16,6 +16,6 @@ watch([name, currentStatus], ([newName, newStatus]) => {
     name: newName,
     status: newStatus,
     uuid: uuid.value,
-    currentNumber: currentNumber.value,
+    allNumbers: allNumbers.value,
   });
 });

--- a/front/src/states/index.ts
+++ b/front/src/states/index.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import { ref } from "vue";
 
 // Game status
-export const currentNumber = ref<number | null>(null);
+export const allNumbers = ref<number[]>([]);
 export const uuid = useLocalStorage("userId", nanoid());
 export const name = useLocalStorage("userName", "");
 

--- a/front/src/views/UserView.vue
+++ b/front/src/views/UserView.vue
@@ -50,6 +50,7 @@ const currentNumber = computed(() => allNumbers.value[allNumbers.value.length - 
 }
 
 .current-number {
+  margin-top: 16px;
   font-size: 40px;
   color: #fff;
 }

--- a/front/src/views/UserView.vue
+++ b/front/src/views/UserView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import BingoUI from '../components/BingoGrid.vue';
-import { currentNumber, grid, name } from '@/states';
+import { allNumbers, grid, name } from '@/states';
 
 const isModalOpen = ref(true);
 
@@ -10,6 +10,9 @@ const toggleModal = () => {
     isModalOpen.value = !isModalOpen.value;
   }
 };
+
+const numberHistory = computed(() => allNumbers.value.slice(0, -1).reverse().join(', '));
+const currentNumber = computed(() => allNumbers.value[allNumbers.value.length - 1]);
 </script>
 
 <template>
@@ -20,6 +23,10 @@ const toggleModal = () => {
     <div class="bingo-info">
       <div class="current-number">
         現在の数字: {{ currentNumber ?? '??' }}
+      </div>
+      <div class="result-item">
+        <span class="result-label">過去の数字:</span>
+        <span class="result-content">{{ numberHistory }}</span>
       </div>
     </div>
 
@@ -51,6 +58,27 @@ const toggleModal = () => {
   padding: 10px 20px;
   font-size: 16px;
   cursor: pointer;
+}
+
+.result-item {
+  display: flex;
+  flex-direction: column;
+  margin: 24px 0;
+  /* Reduced margin */
+  align-items: center;
+}
+
+.result-label {
+  font-weight: bold;
+  color: #ffffff;
+  font-size: 16px;
+  /* Reduced font size */
+}
+
+.result-content {
+  font-size: 24px;
+  /* Reduced font size */
+  color: #ffffff;
 }
 
 /* Modal styles */

--- a/server/main.ts
+++ b/server/main.ts
@@ -42,7 +42,7 @@ adminIo.on("connection", (socket) => {
     if (oldNumbers.value.length === 75) return;
     latestNumber.value = generateNewNumber(oldNumbers.value);
     oldNumbers.value.push(latestNumber.value);
-    io.emit("nextNumber", latestNumber.value);
+    io.emit("allNumbers", oldNumbers.value);
     adminIo.emit("nextNumber", latestNumber.value);
     adminIo.emit("allNumbers", oldNumbers.value);
   });


### PR DESCRIPTION
- [x] UX的にビンゴの番号を追い忘れて分からなくなる現象が起きそうだったので、user画面にも過去の番号を表示するように変更しました
- [x] モバイル表示における「リーチ」「ビンゴ」の位置を中央寄せに調整しました

## スクリーンショット
![image](https://github.com/nkzwlab/jnok-bingo/assets/53967490/f1721a49-29cd-4e81-b489-762f421170d1)
![image](https://github.com/nkzwlab/jnok-bingo/assets/53967490/98598511-4046-4a2d-b62f-49c29cb4b164)

## 備考
デザイン等で修正したい箇所があれば、レビュー時 or マージ後に調整しちゃってください