### PR TITLE
レスポンシブ修正

### DIFF
--- a/front/src/components/BingoGrid.vue
+++ b/front/src/components/BingoGrid.vue
@@ -154,7 +154,7 @@ watch(markedCells, checkBingoAndReach, { deep: true });
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 700px) {
   .bingo-grid {
     max-width: 100%;
     gap: 3px;

--- a/front/src/views/UserView.vue
+++ b/front/src/views/UserView.vue
@@ -79,12 +79,11 @@ const showChat = ref(false);
   margin-top: 16px;
   font-size: 40px;
   color: #fff;
+  text-align: center;
 }
 
-.bingo-info button {
-  padding: 10px 20px;
-  font-size: 16px;
-  cursor: pointer;
+.bingo-info {
+  padding: 0 20px;
 }
 
 .result-item {
@@ -102,6 +101,7 @@ const showChat = ref(false);
 
 .result-content {
   font-size: 24px;
+  text-align: center;
   color: #ffffff;
 }
 


### PR DESCRIPTION
レスポンシブ時のデザインを修正しました。もしローカル側で作業中だった場合は、一旦closeしてmainブランチの中に取り入れてちゃっても大丈夫です
- 700pxあたりに表示崩れがあったので修正
- テキストを中央寄せにし、両横にpaddingを追加

### スクリーンショット
|  修正前 | 修正後 |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/7fd706ae-e525-45ab-a795-81914063303c) | ![image](https://github.com/user-attachments/assets/b1f22a6f-2df3-4dd4-943b-50369fa1f7d6) |



